### PR TITLE
Add support for VCS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,11 @@ simulation-xrun: fstdumper.so
 
 simulation-vsim: fstdumper.so
 	vlog -64 $(TESTBENCH)
-	vsim -64 -c div_int_tb -vpicompatcb -plicompatdefault latest -pli fstdumper.so -do "run -all"
+	vsim -64 -c div_int_tb -vpicompatcb -pli fstdumper.so -do "run -all"
+
+simulation-vcs: fstdumper.so
+	vcs -sverilog -full64 +vpi -load ./fstdumper.so -debug_acc+pp+f+dmptf $(TESTBENCH)
+	./simv
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
The make-file rule "works", but it seems to be a similar problem as with vsim, no signal changes.

Also, for VCS the simulation time goes to ~450 seconds as opposed to vsim's ~450 ns. (Checked using GTKWave 3.3.100, which is the latest with pre-built Windows binaries.)

I removed a flag for vsim which is now deprecated (2021.3 version) and prohibits it from running.

For info, I've been using VCS 2021.09.